### PR TITLE
included systemd sample configuration files

### DIFF
--- a/config/systemd/celery
+++ b/config/systemd/celery
@@ -1,0 +1,21 @@
+CELERYD_NODES="task_processing data_cube_manager"
+
+CELERY_BIN="/home/localuser/Datacube/datacube_env/bin/celery"
+
+CELERY_APP="data_cube_ui"
+DJANGO_SETTINGS_MODULE="data_cube_ui.settings"
+
+# CELERYD_CHDIR: see WorkingDirectory in unit file
+
+# extra command-line arguments for the worker
+CELERYD_OPTS="-c:task_processing 10 -c:data_cube_manager 2 --max-tasks-per-child:data_cube_manager=1 -Q:data_cube_manager data_cube_manager -Ofair"
+
+CELERYD_LOG_LEVEL="INFO"
+
+CELERYD_LOG_FILE="/var/log/celery/%n%I.log"
+CELERYD_PID_FILE="/var/run/celery/%n.pid"
+
+#CELERY_USER: see User in unit file
+#CELERY_GROUP: see Group in unit file
+
+#CELERY_CREATE_DIRS: ???

--- a/config/systemd/celery-beat
+++ b/config/systemd/celery-beat
@@ -1,0 +1,19 @@
+CELERY_BIN="/home/localuser/Datacube/datacube_env/bin/celery"
+
+CELERY_APP="data_cube_ui"
+DJANGO_SETTINGS_MODULE="data_cube_ui.settings"
+
+# CELERYD_CHDIR: see WorkingDirectory in unit file
+
+# extra command-line arguments for the beat service
+CELERYBEAT_OPTS=""
+
+CELERYBEAT_LOG_LEVEL="INFO"
+
+CELERYBEAT_LOG_FILE="/var/log/celery/celery-beat.log"
+CELERYBEAT_PID_FILE="/var/run/celery/celery-beat.pid"
+
+#CELERY_USER: see User in unit file
+#CELERY_GROUP: see Group in unit file
+
+#CELERY_CREATE_DIRS: ???

--- a/config/systemd/celery-beat.service
+++ b/config/systemd/celery-beat.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Celery Beat Service
+After=network.target
+
+[Service]
+User=localuser
+Group=localuser
+EnvironmentFile=/etc/conf.d/celery-beat
+WorkingDirectory=/home/localuser/Datacube/data_cube_ui
+ExecStart=/bin/sh -c '${CELERY_BIN} beat \
+    -A ${CELERY_APP} \
+    --pidfile=${CELERYBEAT_PID_FILE} \
+    --logfile=${CELERYBEAT_LOG_FILE} \
+    --loglevel=${CELERYBEAT_LOG_LEVEL} \
+    --workdir=${CELERYBEAT_WORK_DIR} \
+    ${CELERYBEAT_OPTS}'
+ExecStop=/bin/kill -s TERM $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/config/systemd/celery.conf
+++ b/config/systemd/celery.conf
@@ -1,0 +1,2 @@
+d /var/log/celery 0755 localuser localuser -
+d /var/run/celery 0755 localuser localuser -

--- a/config/systemd/celery.service
+++ b/config/systemd/celery.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Celery Service
+After=network.target
+
+[Service]
+Type=forking
+User=localuser
+Group=localuser
+EnvironmentFile=/etc/conf.d/celery
+WorkingDirectory=/home/localuser/Datacube/data_cube_ui
+ExecStart=/bin/sh -c '${CELERY_BIN} multi start ${CELERYD_NODES} \
+    -A ${CELERY_APP} \
+    --pidfile=${CELERYD_PID_FILE} \
+    --logfile=${CELERYD_LOG_FILE} \
+    --loglevel=${CELERYD_LOG_LEVEL} \
+    ${CELERYD_OPTS}'
+ExecStop=/bin/sh -c '${CELERY_BIN} multi stopwait ${CELERYD_NODES} \
+    --pidfile=${CELERYD_PID_FILE}'
+ExecReload=/bin/sh -c '${CELERY_BIN} multi restart ${CELERYD_NODES} \
+    -A ${CELERY_APP} \
+    --pidfile=${CELERYD_PID_FILE} \
+    --logfile=${CELERYD_LOG_FILE} \
+    --loglevel=${CELERYD_LOG_LEVEL} \
+    ${CELERYD_OPTS}'
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/ui_install.md
+++ b/docs/ui_install.md
@@ -334,9 +334,10 @@ celery -A data_cube_ui beat
 
 To test the workers we will need to add an area and dataset that you have ingested to the UI's database. This will happen in a separate section.
 
-This process can be automated and daemonized with the following snippet:
+This process can be automated and daemonized with the following snippet if your
+system uses Upstart/SysVInit:
 
-```
+```shell
 sudo cp config/celeryd_conf /etc/default/data_cube_ui && sudo cp config/celeryd /etc/init.d/data_cube_ui
 sudo chmod 777 /etc/init.d/data_cube_ui
 sudo chmod 644 /etc/default/data_cube_ui
@@ -351,7 +352,29 @@ sudo /etc/init.d/celerybeat start
 
 This is done in the initial setup script.
 
-You can alias the /etc/init.d/* script as whatever you like - you can start, stop, kill, restart, etc. the workers using this script.
+You can alias the `/etc/init.d/*` script as whatever you like - you can start, stop, kill, restart, etc. the workers using this script.
+
+
+If your Linux uses Systemd (e.g. Debian >= 8, Ubuntu >= 15.04), you can use the
+files provided in `config/systemd` instead (not included in the initial setup script!):
+```shell
+sudo install -vDm644 config/systemd/celery.service /etc/systemd/system/celery.service
+sudo install -vDm644 config/systemd/celery /etc/conf.d/celery
+
+sudo install -vDm644 config/systemd/celery-beat.service /etc/systemd/system/celery-beat.service
+sudo install -vDm644 config/systemd/celery-beat /etc/conf.d/celery-beat
+
+sudo install -vDm644 config/systemd/celery.conf /etc/tmpfiles.d/celery.conf
+sudo systemd-tmpfiles --create
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now celery celery-beat
+```
+
+Starting, Stopping, Restarting etc. is now done with systemctl, e.g.:
+```
+sudo systemctl restart celery
+```
 
 
 <a name="system_overview"></a> Task System Overview


### PR DESCRIPTION
Many of the mainstream Linux distributions like Debian and Ubuntu switched to Systemd as their default init-system as a replacement for SysVInit (or Upstart) 2-3 years ago.

This PR adds sample configuration files for those that want to manage celery with systemctl/Systemd. Instructions on how to install these configuration files have been included in `docs/ui-install.md`.