### PR TITLE
required changes for migrating to Django 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ apps/*/__pycache__/
 */__pycache__/
 data_cube_ui/migrations/
 data_cube_ui/__pycache__/
+.idea

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -281,7 +281,7 @@ def registration(request):
         context = {'title': _("Registration"), 'form': RegistrationForm(),}
         if request.GET:
             next = request.POST.get('next', "/")
-            if request.user.is_authenticated():
+            if request.user.is_authenticated:
                 return redirect(next)
             context['next'] = next
         return render(request, 'registration/registration.html', context)
@@ -337,7 +337,7 @@ def login(request):
         context = {'title': _("Log in"), 'form': LoginForm() }
         if request.GET:
             next = request.GET.get('next', "/")
-            if request.user.is_authenticated():
+            if request.user.is_authenticated:
                 return redirect(next)
             context['next'] = next
         return render(request, 'registration/login.html', context)

--- a/apps/coastal_change/models.py
+++ b/apps/coastal_change/models.py
@@ -72,7 +72,7 @@ class Query(BaseQuery):
     time_end = models.IntegerField()
     time_start = models.IntegerField()
 
-    animated_product = models.ForeignKey(AnimationType)
+    animated_product = models.ForeignKey(AnimationType, on_delete=models.CASCADE)
 
     base_result_dir = '/datacube/ui_results/coastal_change'
 

--- a/apps/custom_mosaic_tool/models.py
+++ b/apps/custom_mosaic_tool/models.py
@@ -79,9 +79,9 @@ class Query(BaseQuery):
     foreign keys should define __str__ for a human readable name.
 
     """
-    query_type = models.ForeignKey(ResultType)
-    animated_product = models.ForeignKey(AnimationType)
-    compositor = models.ForeignKey(Compositor)
+    query_type = models.ForeignKey(ResultType, on_delete=models.CASCADE)
+    animated_product = models.ForeignKey(AnimationType, on_delete=models.CASCADE)
+    compositor = models.ForeignKey(Compositor, on_delete=models.CASCADE)
 
     base_result_dir = '/datacube/ui_results/custom_mosaic_tool'
 

--- a/apps/dc_algorithm/management/commands/band_math_app/models.py
+++ b/apps/dc_algorithm/management/commands/band_math_app/models.py
@@ -59,7 +59,7 @@ class Query(BaseQuery):
     foreign keys should define __str__ for a human readable name.
 
     """
-    compositor = models.ForeignKey(Compositor)
+    compositor = models.ForeignKey(Compositor, on_delete=models.CASCADE)
 
     #TODO: add color scale here
     color_scale_path = '/home/' + settings.LOCAL_USER + '/Datacube/data_cube_ui/utils/color_scales/default_color_scale'

--- a/apps/dc_algorithm/management/commands/base_app/models.py
+++ b/apps/dc_algorithm/management/commands/base_app/models.py
@@ -87,9 +87,9 @@ class Query(BaseQuery):
     """
 
     # TODO: Are there querytypes, animation types, or compositors that need to be distinguished?
-    query_type = models.ForeignKey(ResultType)
-    animated_product = models.ForeignKey(AnimationType)
-    compositor = models.ForeignKey(Compositor)
+    query_type = models.ForeignKey(ResultType, on_delete=models.CASCADE)
+    animated_product = models.ForeignKey(AnimationType, on_delete=models.CASCADE)
+    compositor = models.ForeignKey(Compositor, on_delete=models.CASCADE)
 
     # TODO: Fill out the configuration paths
     base_result_dir = '/datacube/ui_results/app_name'

--- a/apps/dc_algorithm/models/abstract_base_models.py
+++ b/apps/dc_algorithm/models/abstract_base_models.py
@@ -65,7 +65,7 @@ class Query(models.Model):
 
     area_id = models.CharField(max_length=100)
 
-    satellite = models.ForeignKey('dc_algorithm.Satellite')
+    satellite = models.ForeignKey('dc_algorithm.Satellite', on_delete=models.CASCADE)
 
     time_start = models.DateField('time_start')
     time_end = models.DateField('time_end')

--- a/apps/dc_algorithm/models/application_models.py
+++ b/apps/dc_algorithm/models/application_models.py
@@ -207,7 +207,7 @@ class Application(models.Model):
 
     color_scale = models.CharField(max_length=250, default="", blank=True, null=True)
 
-    application_group = models.ForeignKey('ApplicationGroup', null=True, blank=True)
+    application_group = models.ForeignKey('ApplicationGroup', on_delete=models.CASCADE, null=True, blank=True)
 
     def __str__(self):
         return self.id

--- a/apps/fractional_cover/models.py
+++ b/apps/fractional_cover/models.py
@@ -58,7 +58,7 @@ class Query(BaseQuery):
     foreign keys should define __str__ for a human readable name.
 
     """
-    compositor = models.ForeignKey(Compositor)
+    compositor = models.ForeignKey(Compositor, on_delete=models.CASCADE)
 
     base_result_dir = '/datacube/ui_results/fractional_cover'
 

--- a/apps/slip/models.py
+++ b/apps/slip/models.py
@@ -71,7 +71,7 @@ class Query(BaseQuery):
 
     """
 
-    baseline_method = models.ForeignKey(BaselineMethod)
+    baseline_method = models.ForeignKey(BaselineMethod, on_delete=models.CASCADE)
     baseline_length = models.IntegerField(default=10)
 
     base_result_dir = '/datacube/ui_results/slip'

--- a/apps/spectral_indices/models.py
+++ b/apps/spectral_indices/models.py
@@ -67,8 +67,8 @@ class Query(BaseQuery):
     foreign keys should define __str__ for a human readable name.
 
     """
-    compositor = models.ForeignKey(Compositor)
-    query_type = models.ForeignKey(ResultType)
+    compositor = models.ForeignKey(Compositor, on_delete=models.CASCADE)
+    query_type = models.ForeignKey(ResultType, on_delete=models.CASCADE)
 
     color_scale_path = {
         'ndvi': '/home/' + settings.LOCAL_USER + '/Datacube/data_cube_ui/utils/color_scales/ndvi',

--- a/apps/tsm/models.py
+++ b/apps/tsm/models.py
@@ -77,8 +77,8 @@ class Query(BaseQuery):
 
     """
 
-    query_type = models.ForeignKey(ResultType)
-    animated_product = models.ForeignKey(AnimationType)
+    query_type = models.ForeignKey(ResultType, on_delete=models.CASCADE)
+    animated_product = models.ForeignKey(AnimationType, on_delete=models.CASCADE)
 
     base_result_dir = '/datacube/ui_results/tsm'
 

--- a/apps/urbanization/models.py
+++ b/apps/urbanization/models.py
@@ -59,7 +59,7 @@ class Query(BaseQuery):
     foreign keys should define __str__ for a human readable name.
 
     """
-    compositor = models.ForeignKey(Compositor)
+    compositor = models.ForeignKey(Compositor, on_delete=models.CASCADE)
 
     base_result_dir = '/datacube/ui_results/urbanization'
 

--- a/apps/water_detection/models.py
+++ b/apps/water_detection/models.py
@@ -76,8 +76,8 @@ class Query(BaseQuery):
 
     """
 
-    query_type = models.ForeignKey(ResultType)
-    animated_product = models.ForeignKey(AnimationType)
+    query_type = models.ForeignKey(ResultType, on_delete=models.CASCADE)
+    animated_product = models.ForeignKey(AnimationType, on_delete=models.CASCADE)
 
     base_result_dir = '/datacube/ui_results/water_detection'
     color_scales = {

--- a/data_cube_ui/settings.py
+++ b/data_cube_ui/settings.py
@@ -83,13 +83,12 @@ INSTALLED_APPS = [
     'bootstrap3',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]


### PR DESCRIPTION
This PR fixes some deprecations/changes that Django 2 introduced. If this PR is merged, it should be possible to use the Datacube UI with Django 2.

The following points of [the Django 2 changelog](https://docs.djangoproject.com/en/2.1/releases/2.0/) had to be addressed:

- The SessionAuthenticationMiddleware class is removed. It provided no functionality since session authentication is unconditionally enabled in Django 1.10.
- The on_delete argument for ForeignKey and OneToOneField is now required in models and migrations. Consider squashing migrations so that you have fewer of them to update.
- Using User.is_authenticated() and User.is_anonymous() as methods rather than properties is no longer supported.