### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ Shapely==1.7.0
 SQLAlchemy==1.3.18
 stringcase==1.2.0
 xarray==0.16.0
+psycopg2==2.8.6


### PR DESCRIPTION
Django 1.11.27 has a safety check to ensure Postgres is running in UTC. This check was removed in Django 3.1 when multi-TZ support for Postgres was added. That check is implemented by looking at offset == 0. Psycopg 2.9 changes the offset value from an integer to a timedelta object. So the check now fails as timedelta(0) != 0. The most obvious solution would be to downgrade to psycopg 2.8.6 adding psycopg2==2.8.6 to the requirements.txt file.